### PR TITLE
Straighten out some Sass (Vendor prefixes, tabs/spaces)

### DIFF
--- a/_sass/_an.scss
+++ b/_sass/_an.scss
@@ -2,13 +2,13 @@
 
 	h4 {
 		text-transform: uppercase;
-		
+
 		&.first_line {
 			text-transform: none;
 			color: $the-blue;
 			font-size: 1.5em;
 		}
-		
+
 		.graytext {
 			text-transform: uppercase;
 			color: $the-gray;
@@ -30,25 +30,25 @@
 		font-size: 20px !important;
 		font-weight: 400 !important;
 		text-transform: uppercase;
-	
+
 		&:hover {
 			background-color: darken($the-pink, 25%) !important;
 		}
 	}
-	
+
 	#d_sharing {
-	
+
 		ul {
 			margin-left: 0;
 			color: $the-gray !important;
 			font-size: 12px;
 		}
 	}
-	
+
 	.main_action_image {
 		width: 90%;
 	}
-	
+
 	#can_sidebar {
 		width: 35%;
 		background-color: lighten($the-green, 15%);
@@ -57,27 +57,27 @@
 		float: right;
 		padding: 15px 20px;
 	}
-	
+
 	ul {
 		font-size: 14px;
 	}
 }
 
 .can_fundraising_widget {
-	
+
 	h2.line {
 		display: none;
 	}
-	
+
 	#donation_recipient_wrap {
 		display: none;
 	}
-	
+
 	#donation_welcome {
 		clear: both;
 		margin-top: 15px !important;
 	}
-	
+
 	#donate_form_button {
 		font-family: 'sans-serif' !important;
 	}
@@ -91,19 +91,19 @@ h4.action_target {
 	width: 60%;
 	max-width: 655px;
 	float: left;
-	
+
 	.last_line {
 		width: 98%;
-		
+
 		h2 {
 			text-transform: uppercase;
 		}
 	}
-	
+
 	h2 {
 		margin-top: 50px;
-	}	
-	
+	}
+
 	.event_full {
 		width: 98%;
 	}
@@ -128,13 +128,13 @@ h4.action_target {
 ul#footer {
 	margin: 0 auto;
 	height: 40px;
-	  
+
 	li {
 		display: inline-block;
 		padding: 5px 30px 0 0;
 		font-size: 17px;
 		position: relative;
-		
+
 		a {
 			color: $the-pink;
 			font-size: 18px;
@@ -147,7 +147,7 @@ ul#footer {
 
 		a:hover {
 			color: $the-gray;
-			@include fade-transition(color 500ms);
+			transition: color 500ms;
 		}
 	}
 }
@@ -157,13 +157,13 @@ ul#footer {
 	padding-top: 2px;
 	margin-top: 10px;
 	@include radius(10px);
-	
+
 	a {
 		color: #ddd;
 	}
-	
+
 	&:hover {
 		background-color: darken($the-pink, 25%) !important;
-		@include fade-transition(background-color 500ms);
+		transition: background-color 500ms;
 	}
 }

--- a/_sass/_an.scss
+++ b/_sass/_an.scss
@@ -53,7 +53,7 @@
 		width: 35%;
 		background-color: lighten($the-green, 15%);
 		position: relative;
-		@include radius(10px);
+		border-radius: 10px;
 		float: right;
 		padding: 15px 20px;
 	}
@@ -156,7 +156,7 @@ ul#footer {
 	background-color: $the-pink;
 	padding-top: 2px;
 	margin-top: 10px;
-	@include radius(10px);
+	border-radius: 10px;
 
 	a {
 		color: #ddd;

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -100,7 +100,7 @@ h1 {
 }
 
 h2 {
-	
+
 }
 
 #nomargin {
@@ -110,7 +110,7 @@ h2 {
 /**
   * Body
   */
-  
+
 p {
 	text-align: justify;
 	padding-right: 10px;
@@ -133,14 +133,14 @@ a {
     &:hover {
         color: $the-gray;
 		outline: 0;
-		@include fade-transition(color 500ms);
+		transition: color 500ms;
 
     }
-	
+
 	&:focus {
 		outline: thin dotted;
 	}
-	
+
 	&:active {
 		outline: 0;
 	}
@@ -246,7 +246,7 @@ pre {
   * Non-semantic helper classes
   * Please define your styles before this section.
   */
-  
+
 /* For image replacement */
 
 .ir {
@@ -256,7 +256,7 @@ pre {
 	background-repeat: no-repeat;
 	text-align: left;
 	direction: ltr;
-	
+
 	br {
 		display: none;
 	}

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -4,8 +4,8 @@
 body, h1, h2, h3, h4, h5, h6,
 p, blockquote, pre, hr,
 dl, dd, ol, ul, figure {
-    margin: 0;
-    padding: 0;
+	margin: 0;
+	padding: 0;
 }
 
 article, aside, details, figcaption, figure, footer, header, hgroup, nav, section {
@@ -29,14 +29,14 @@ html {
 }
 
 body {
-    font-family: $base-font-family;
-    font-size: $base-font-size;
-    line-height: $base-line-height;
+	font-family: $base-font-family;
+	font-size: $base-font-size;
+	line-height: $base-line-height;
 	font-size: 13px;
 	line-height: 1.231;
-    font-weight: 300;
-    color: $text-color;
-    background-color: $the-beige;
+	font-weight: 300;
+	color: $text-color;
+	background-color: $the-beige;
 }
 
 /**
@@ -46,15 +46,15 @@ h1, h2, h3, h4, h5, h6,
 p, blockquote, pre,
 ul, ol, dl, figure,
 %vertical-rhythm {
-    margin-bottom: $spacing-unit / 2;
+	margin-bottom: $spacing-unit / 2;
 }
 
 /**
  * Images
  */
 img {
-    max-width: 100%;
-    vertical-align: middle;
+	max-width: 100%;
+	vertical-align: middle;
 	padding-bottom: 10px;
 }
 
@@ -62,32 +62,32 @@ img {
  * Figures
  */
 figure > img {
-    display: block;
+	display: block;
 }
 
 figcaption {
-    font-size: $small-font-size;
+	font-size: $small-font-size;
 }
 
 /**
  * Lists
  */
 ul, ol {
-    margin-left: $spacing-unit;
+	margin-left: $spacing-unit;
 }
 
 li {
-    > ul,
-    > ol {
-         margin-bottom: 0;
-    }
+	> ul,
+	> ol {
+		margin-bottom: 0;
+	}
 }
 
 /**
  * Headings
  */
 h1, h2, h3, h4, h5, h6 {
-    font-weight: 300;
+	font-weight: 300;
 	font-family: $header-font-family;
 }
 
@@ -104,7 +104,7 @@ h2 {
 }
 
 #nomargin {
-		margin-bottom: 0;
+	margin-bottom: 0;
 }
 
 /**
@@ -127,15 +127,14 @@ p {
  * Links
  */
 a {
-    color: $the-pink;
-    text-decoration: none;
+	color: $the-pink;
+	text-decoration: none;
 
-    &:hover {
-        color: $the-gray;
+	&:hover {
+		color: $the-gray;
 		outline: 0;
 		transition: color 500ms;
-
-    }
+	}
 
 	&:focus {
 		outline: thin dotted;
@@ -150,16 +149,16 @@ a {
  * Blockquotes
  */
 blockquote {
-    color: $grey-color;
-    border-left: 4px solid $grey-color-light;
-    padding-left: $spacing-unit / 2;
-    font-size: 18px;
-    letter-spacing: -1px;
-    font-style: italic;
+	color: $grey-color;
+	border-left: 4px solid $grey-color-light;
+	padding-left: $spacing-unit / 2;
+	font-size: 18px;
+	letter-spacing: -1px;
+	font-style: italic;
 
-    > :last-child {
-        margin-bottom: 0;
-    }
+	> :last-child {
+		margin-bottom: 0;
+	}
 }
 
 /**
@@ -167,25 +166,25 @@ blockquote {
  */
 pre,
 code {
-    font-size: 15px;
-    border: 1px solid $grey-color-light;
-    border-radius: 3px;
-    background-color: #eef;
+	font-size: 15px;
+	border: 1px solid $grey-color-light;
+	border-radius: 3px;
+	background-color: #eef;
 }
 
 code {
-    padding: 1px 5px;
+	padding: 1px 5px;
 }
 
 pre {
-    padding: 8px 12px;
-    overflow-x: scroll;
+	padding: 8px 12px;
+	overflow-x: scroll;
 
-    > code {
-        border: 0;
-        padding-right: 0;
-        padding-left: 0;
-    }
+	> code {
+		border: 0;
+		padding-right: 0;
+		padding-left: 0;
+	}
 }
 
 
@@ -194,11 +193,11 @@ pre {
  * Wrapper
  */
 .wrapper {
-    max-width: -webkit-calc(1000px - (#{$spacing-unit} * 2));
-    max-width:         calc(1000px - (#{$spacing-unit} * 2));
-    margin-right: auto;
-    margin-left: auto;
-    @extend %clearfix;
+	max-width: -webkit-calc(1000px - (#{$spacing-unit} * 2));
+	max-width:         calc(1000px - (#{$spacing-unit} * 2));
+	margin-right: auto;
+	margin-left: auto;
+	@extend %clearfix;
 
 /*    @include media-query($medium) {
  *       max-width: -webkit-calc(1000px - (#{$spacing-unit}));
@@ -216,11 +215,11 @@ pre {
  */
 %clearfix {
 
-    &:after {
-        content: "";
-        display: table;
-        clear: both;
-    }
+	&:after {
+		content: "";
+		display: table;
+		clear: both;
+	}
 }
 
 
@@ -230,16 +229,16 @@ pre {
  */
 .icon {
 
-    > svg {
-        display: inline-block;
-        width: 16px;
-        height: 16px;
-        vertical-align: middle;
+	> svg {
+		display: inline-block;
+		width: 16px;
+		height: 16px;
+		vertical-align: middle;
 
-        path {
-            fill: $grey-color;
-        }
-    }
+		path {
+			fill: $grey-color;
+		}
+	}
 }
 
 /**

--- a/_sass/_grid.scss
+++ b/_sass/_grid.scss
@@ -2,7 +2,7 @@ ul.rig {
 	list-style: none;
 	font-size: 0px;
 	margin-left: 2.5%;
-	
+
 	li {
 		display: inline-block;
 		padding: 10px;
@@ -18,31 +18,31 @@ ul.rig {
 		width: 30.84%;
 		margin-right: 2.49%;
 		margin-top: 10px;
-		
+
 		img {
 			max-width: 100%;
 			height: auto;
 			margin: 0;
 		}
-		
+
 		p {
 			font-style: italic;
 			text-align: center;
 		}
-		
+
 		span {
 			line-height: 22px;
 		}
-		
+
 		h2 {
 			margin-bottom: 10px;
-			
+
 			a {
 				color: $the-blue;
-			
+
 				&:hover {
 					color: darken($the-blue, 25%) !important;
-					@include fade-transition(color 500ms);
+					transition: color 500ms;
 				}
 			}
 		}
@@ -52,7 +52,7 @@ ul.rig {
 @include media-query($small){
 	ul.rig {
 		margin-left: 0;
-	
+
 		li {
 			width: 100%;
 			margin: 0 0 20px;
@@ -63,7 +63,7 @@ ul.rig {
 @media only screen
 	and (max-width: 992px)
 	and (min-width: 769px) {
-	
+
 	ul.rig li {
 		width: 47.5%;
 	}

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -123,69 +123,69 @@ header {
 }
 
 nav#top-links {
-		display: block;
+	display: block;
 
-		ul {
-			margin: 0 auto;
-			height: 40px;
+	ul {
+		margin: 0 auto;
+		height: 40px;
 
-			li {
-				display: inline-block;
-				font-size: 17px;
-				padding: 9px 0;
-				max-width: 184px;
-				min-width: 147px;
-				width: 19.55%;
-				text-align: center;
-				border-right: 2px solid #3c393a;
-				border-left: 2px solid #000;
-				background-color: #231f20;
-				position: relative;
-				margin-top: 15px;
-				margin-left: -4px;
+		li {
+			display: inline-block;
+			font-size: 17px;
+			padding: 9px 0;
+			max-width: 184px;
+			min-width: 147px;
+			width: 19.55%;
+			text-align: center;
+			border-right: 2px solid #3c393a;
+			border-left: 2px solid #000;
+			background-color: #231f20;
+			position: relative;
+			margin-top: 15px;
+			margin-left: -4px;
 
-				ul.dropdown {
-					position: absolute;
-					top: 40px;
-					z-index: 9000;
+			ul.dropdown {
+				position: absolute;
+				top: 40px;
+				z-index: 9000;
 
-					li {
-						border-radius: 0;
-						border: 0;
-						margin: 0;
-					}
+				li {
+					border-radius: 0;
+					border: 0;
+					margin: 0;
 				}
+			}
 
-				a {
-					color: #e8e8e8;
-					font-size: 18px;
-					text-decoration: none;
-					font-family: 'league-gothic';
-					text-transform: uppercase;
-					display: block;
-					height: auto;
-				}
+			a {
+				color: #e8e8e8;
+				font-size: 18px;
+				text-decoration: none;
+				font-family: 'league-gothic';
+				text-transform: uppercase;
+				display: block;
+				height: auto;
+			}
 
-				a.active {
-					color: $the-yellow;
-				}
+			a.active {
+				color: $the-yellow;
+			}
 
 
-				&:first-child {
-					border-left: 0;
-					border-radius: 10px 0px 0px 10px;
-					margin-left: 0;
-				}
+			&:first-child {
+				border-left: 0;
+				border-radius: 10px 0px 0px 10px;
+				margin-left: 0;
+			}
 
-				&:last-child {
-					border-right: 0;
-					border-radius: 0px 10px 10px 0px;
-				}
+			&:last-child {
+				border-right: 0;
+				border-radius: 0px 10px 10px 0px;
+			}
 
-				&:hover {
-					background-color: $the-pink;
-					transition: background-color 500ms;
-				}
+			&:hover {
+				background-color: $the-pink;
+				transition: background-color 500ms;
 			}
 		}
 	}
+}

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -75,7 +75,7 @@ header {
 		float: left;
 		width: 300px;
 		margin: 0 10px;
-		@include radius(0 0 10px 10px);
+		border-radius: 0 0 10px 10px;
 		padding: 0 10px;
 		margin-right: 0;
 		margin-left: 90px;
@@ -102,7 +102,7 @@ header {
 			display: inline-block;
 			padding: 3px 5px;
 			font-size: 1.2em;
-			@include radius(5px);
+			border-radius: 5px;
 			float: right;
 			color: white;
 			font-family: "league-gothic";
@@ -173,13 +173,13 @@ nav#top-links {
 
 				&:first-child {
 					border-left: 0;
-					@include radius(10px 0px 0px 10px);
+					border-radius: 10px 0px 0px 10px;
 					margin-left: 0;
 				}
 
 				&:last-child {
-					border-right:0;
-					@include radius(0px 10px 10px 0px);
+					border-right: 0;
+					border-radius: 0px 10px 10px 0px;
 				}
 
 				&:hover {

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -14,7 +14,7 @@ header {
 		padding-top: 15px;
 		*zoom: 1;
 		margin-left: 0;
-	
+
 		div {
 			float: left;
 			margin-right: 20px;
@@ -24,7 +24,7 @@ header {
 			width: 131px;
 			height: 85px;
 			position: relative;
-		
+
 			span {
 				position: absolute;
 				top: 0;
@@ -35,41 +35,40 @@ header {
 				background-repeat: no-repeat;
 				background-position: 0 0;
 				opacity: 0;
-				@include fade-transition(opacity 0.5s);
-	  
+				transition: opacity 500ms;
 				&:hover {
 					opacity: 1;
 				}
 			}
-		
+
 		}
-	
+
 		hgroup {
 			padding: 25px 0 15px 40px;
-	  
+
 			h1 {
 				font-size: 48px;
 				line-height: 40px;
 				margin: 0;
 				font-weight: bold;
 			}
-		
+
 			h2 {
 				margin: 0;
 				font-size: 18px;
 			}
 		}
-	
+
 		&:before, &:after {
 			content: "";
 			display: table;
 		}
-  
+
 		&:after {
 			clear: both;
 		}
 	}
-  
+
 	#register-widget {
 		background-color: $the-green;
 		height: 105px;
@@ -82,7 +81,7 @@ header {
 		margin-left: 90px;
 		@include bsizing(border-box);
 		padding: 5px;
-	
+
 		h3 {
 			font-size: 21px;
 			margin-bottom: 0;
@@ -90,14 +89,14 @@ header {
 			text-align: center;
 			color: white;
 		}
-		
+
 		h4 {
 			font-size: 16px;
 			margin-top: 57px;
 			text-align: center;
 			line-height: 0;
 		}
-	  
+
 		span {
 			background-color: $the-blue;
 			display: inline-block;
@@ -114,9 +113,9 @@ header {
 			margin-left: 65px;
 			margin-top: 10px;
 			@include bshadow(2px 3px 0px #bacc3f);
-  
+
 			&:hover {
-				@include fade-transition(background-color 500ms);
+				transition: background-color 500ms;
 				background-color: $the-pink;
 			}
 		}
@@ -125,11 +124,11 @@ header {
 
 nav#top-links {
 		display: block;
-  
+
 		ul {
 			margin: 0 auto;
 			height: 40px;
-	  
+
 			li {
 				display: inline-block;
 				font-size: 17px;
@@ -144,19 +143,19 @@ nav#top-links {
 				position: relative;
 				margin-top: 15px;
 				margin-left: -4px;
-			
+
 				ul.dropdown {
 					position: absolute;
 					top: 40px;
 					z-index: 9000;
-				
+
 					li {
 						border-radius: 0;
 						border: 0;
 						margin: 0;
 					}
 				}
-		
+
 				a {
 					color: #e8e8e8;
 					font-size: 18px;
@@ -166,26 +165,26 @@ nav#top-links {
 					display: block;
 					height: auto;
 				}
-			
+
 				a.active {
 					color: $the-yellow;
 				}
-				
-	  
+
+
 				&:first-child {
 					border-left: 0;
 					@include radius(10px 0px 0px 10px);
 					margin-left: 0;
 				}
-	  
+
 				&:last-child {
 					border-right:0;
 					@include radius(0px 10px 10px 0px);
 				}
-	  
+
 				&:hover {
 					background-color: $the-pink;
-					@include fade-transition(background-color 500ms);
+					transition: background-color 500ms;
 				}
 			}
 		}

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -79,7 +79,7 @@ header {
 		padding: 0 10px;
 		margin-right: 0;
 		margin-left: 90px;
-		@include bsizing(border-box);
+		box-sizing: border-box;
 		padding: 5px;
 
 		h3 {

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -112,7 +112,7 @@ header {
 			margin-right: 65px;
 			margin-left: 65px;
 			margin-top: 10px;
-			@include bshadow(2px 3px 0px #bacc3f);
+			box-shadow: 2px 3px 0px #bacc3f;
 
 			&:hover {
 				transition: background-color 500ms;

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -171,14 +171,14 @@ h2 {
 }
 
 .featurebox {
-	@include radius(10px);
+	border-radius: 10px;
 	padding: 1em;
 	background: $the-light-beige;
 	margin-bottom: 1.2em;
 	width: 80%;
 	margin-left: auto;
 	margin-right: auto;
-	
+
 	ul {
 		font-size: 14px;
 		line-height: 2.14em;

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -2,43 +2,43 @@
  * Site header
  */
 .site-header {
-    border-top: 5px solid $grey-color-dark;
-    min-height: 56px;
+	border-top: 5px solid $grey-color-dark;
+	min-height: 56px;
 
-    // Positioning context for the mobile navigation icon
-    position: relative;
+	// Positioning context for the mobile navigation icon
+	position: relative;
 }
 
 .site-title {
-    font-size: 26px;
-    line-height: 56px;
-    letter-spacing: -1px;
-    margin-bottom: 0;
-    float: left;
+	font-size: 26px;
+	line-height: 56px;
+	letter-spacing: -1px;
+	margin-bottom: 0;
+	float: left;
 
-    &,
-    &:visited {
-        color: $grey-color-dark;
-    }
+	&,
+	&:visited {
+		color: $grey-color-dark;
+	}
 }
 
 .site-nav {
-    float: right;
-    line-height: 56px;
+	float: right;
+	line-height: 56px;
 
-    .menu-icon {
-        display: none;
-    }
+	.menu-icon {
+		display: none;
+	}
 
-    .page-link {
-        color: $text-color;
-        line-height: $base-line-height;
+	.page-link {
+		color: $text-color;
+		line-height: $base-line-height;
 
-        // Gaps between nav items, but not on the first one
-        &:not(:first-child) {
-            margin-left: 20px;
-        }
-    }
+		// Gaps between nav items, but not on the first one
+		&:not(:first-child) {
+			margin-left: 20px;
+		}
+	}
 }
 
 
@@ -47,7 +47,7 @@
  * Site footer
  */
 .site-footer {
-    padding: 20px 0 10px 0;
+	padding: 20px 0 10px 0;
 	border-top: 1px $the-gray solid;
 }
 
@@ -101,26 +101,26 @@ h2 {
 }
 
 .page-heading {
-    font-size: 20px;
+	font-size: 20px;
 }
 
 .post-list {
-    margin-left: 0;
-    list-style: none;
+	margin-left: 0;
+	list-style: none;
 
-    > li {
-        margin-bottom: $spacing-unit;
-    }
+	> li {
+		margin-bottom: $spacing-unit;
+	}
 }
 
 .post-meta {
-    font-size: $small-font-size;
-    color: $grey-color;
+	font-size: $small-font-size;
+	color: $grey-color;
 }
 
 .post-link {
-    display: block;
-    font-size: 24px;
+	display: block;
+	font-size: 24px;
 }
 
 
@@ -133,41 +133,41 @@ h2 {
 }
 
 .post-title {
-    font-size: 42px;
-    letter-spacing: -1px;
-    line-height: 1;
+	font-size: 42px;
+	letter-spacing: -1px;
+	line-height: 1;
 
-    @include media-query($medium) {
-        font-size: 36px;
-    }
+	@include media-query($medium) {
+		font-size: 36px;
+	}
 }
 
 .post-content {
-    margin-bottom: $spacing-unit;
+	margin-bottom: $spacing-unit;
 
-    h2 {
-        font-size: 28px;
+	h2 {
+		font-size: 28px;
 
-        @include media-query($medium) {
-            font-size: 28px;
-        }
-    }
+		@include media-query($medium) {
+			font-size: 28px;
+		}
+	}
 
-    h3 {
-        font-size: 24px;
+	h3 {
+		font-size: 24px;
 
-        @include media-query($medium) {
-            font-size: 22px;
-        }
-    }
+		@include media-query($medium) {
+			font-size: 22px;
+		}
+	}
 
-    h4 {
-        font-size: 20px;
+	h4 {
+		font-size: 20px;
 
-        @include media-query($medium) {
-            font-size: 18px;
-        }
-    }
+		@include media-query($medium) {
+			font-size: 18px;
+		}
+	}
 }
 
 .featurebox {

--- a/_sass/_mobile.scss
+++ b/_sass/_mobile.scss
@@ -1,74 +1,74 @@
 /* Small Device */
 
-@media only screen 
+@media only screen
 	and (max-width: 768px) {
-	
+
 	/* General */
-	
+
 	.wrapper {
 		width: 95%;
 	}
-	
+
 	header #logo {
 		width: 131px;
 		float: none;
 		margin: auto;
-		
+
 		hgroup {
-		
+
 			h1 {
 				display: none;
 			}
 		}
 	}
-	
+
 	nav#top-links {
-		
+
 		ul {
-		
+
 			li {
 				max-width: 100%;
 			}
 		}
 	}
-	
+
 	/* Homepage */
-	
+
 	.home {
 		width: 100%;
 		float: none;
 		margin-top: 0;
 	}
-	
+
 	.site-header {
 		height: auto;
-		
+
 		#top-links ul {
 			height: auto;
 			margin-top: 5px;
-			
+
 			li {
 				width: 100%;
 				border-right: 0;
 				border-left: 0;
 				margin-left: 0;
 				margin-top: 3px;
-				
+
 				&:first-child, &:last-child {
-					@include radius(0);
+					border-radius: 0;
 				}
-				
+
 				a {
 					width: 100%;
 				}
 			}
 		}
 	}
-	
+
 	/* Petition Page */
-	
+
 	#can_embed_form {
-		
+
 		h4 {
 			text-transform: uppercase;
 		}
@@ -88,27 +88,27 @@
 			font-size: 20px !important;
 			font-weight: 400 !important;
 			text-transform: uppercase;
-	
+
 			&:hover {
 				background-color: darken($the-pink, 25%) !important;
 			}
 		}
-	
+
 		#d_sharing {
-	
+
 			ul {
 				margin-left: 0;
 				color: $the-gray !important;
 			}
 		}
-  
+
 		#can_main_col {
 			float: none;
 			margin: auto;
 			width: 100%;
 			margin-top: 20px;
 		}
-	
+
 		#can_sidebar {
 			clear: both;
 			float: none;
@@ -116,23 +116,23 @@
 			width: 100%;
 			padding: 0;
 			background-color: lighten($the-green, 15%);
-			@include radius(10px);
-			
+			border-radius: 10px;
+
 			.action_widget {
 				padding-top: 10px;
 			}
-		
+
 			.action_sidebar {
 				padding: 0 10px 10px;
 				margin-bottom: $spacing-unit;
 			}
 		}
 	}
-	
+
 	#can_embed_form.can_thank_you_wrap.can_float {
 		padding-top: 20px;
 	}
-	
+
 	ul#footer {
 		height: auto;
 		margin-bottom: 20px;
@@ -141,7 +141,7 @@
 
 /* Medium Device */
 
-@media only screen 
+@media only screen
 	and (max-width: 992px)
 	and (min-width: 769px) {
 

--- a/_sass/_pagination.scss
+++ b/_sass/_pagination.scss
@@ -11,7 +11,7 @@
 		color: $grey-color-light;
 		padding: 2px 15px;
 		margin: 10px;
-		@include radius(10px);
+		border-radius: 10px;
 
 		&#the-page {
 			background-color: $the-green;

--- a/_sass/_pagination.scss
+++ b/_sass/_pagination.scss
@@ -5,24 +5,24 @@
 	font-family: $header-font-family;
 	font-size: $header-font-size;
 	width: 100%;
-	
+
 	span {
 		background-color: $the-blue;
 		color: $grey-color-light;
 		padding: 2px 15px;
 		margin: 10px;
 		@include radius(10px);
-		
+
 		&#the-page {
 			background-color: $the-green;
 		}
-		
+
 		a {
 			color: $the-yellow;
-			
+
 			&:hover {
 				color: $the-gray;
-				@include fade-transition(500ms);
+				transition: color 500ms;
 			}
 		}
 	}

--- a/_sass/_share.scss
+++ b/_sass/_share.scss
@@ -15,7 +15,7 @@
 		margin-right: 65px;
 		margin-left: 65px;
 		margin-bottom: 20px;
-		@include bshadow(2px 3px 0px #bacc3f);
+		box-shadow: 2px 3px 0px #bacc3f;
 
 		&:hover {
 			transition: background-color 500ms;

--- a/_sass/_share.scss
+++ b/_sass/_share.scss
@@ -1,5 +1,5 @@
 .share-page {
-    text-align: center;
+	text-align: center;
 
 	span {
 		background-color: $the-pink;
@@ -23,8 +23,8 @@
 		}
 	}
 
-    a {
-        font-weight: 400;
-        color: #fff;
-    }
+	a {
+		font-weight: 400;
+		color: #fff;
+	}
 }

--- a/_sass/_share.scss
+++ b/_sass/_share.scss
@@ -6,7 +6,7 @@
 		display: inline-block;
 		padding: 3px 5px;
 		font-size: 1.8em;
-		@include radius(5px);
+		border-radius: 5px;
 		color: white;
 		font-family: "league-gothic";
 		text-transform: uppercase;

--- a/_sass/_share.scss
+++ b/_sass/_share.scss
@@ -1,6 +1,6 @@
 .share-page {
     text-align: center;
-	
+
 	span {
 		background-color: $the-pink;
 		display: inline-block;
@@ -16,9 +16,9 @@
 		margin-left: 65px;
 		margin-bottom: 20px;
 		@include bshadow(2px 3px 0px #bacc3f);
- 
+
 		&:hover {
-			@include fade-transition(background-color 500ms);
+			transition: background-color 500ms;
 			background-color: darken($the-pink, 25%);
 		}
 	}

--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -7,5 +7,5 @@
 	background-color: #fff;
 	width: 290px;
 	padding: 5px;
-	@include radius(5px);
+	border-radius: 5px;
 }

--- a/_sass/_syntax-highlighting.scss
+++ b/_sass/_syntax-highlighting.scss
@@ -2,66 +2,66 @@
  * Syntax highlighting styles
  */
 .highlight {
-    background: #fff;
-    @extend %vertical-rhythm;
+	background: #fff;
+	@extend %vertical-rhythm;
 
-    .c     { color: #998; font-style: italic } // Comment
-    .err   { color: #a61717; background-color: #e3d2d2 } // Error
-    .k     { font-weight: bold } // Keyword
-    .o     { font-weight: bold } // Operator
-    .cm    { color: #998; font-style: italic } // Comment.Multiline
-    .cp    { color: #999; font-weight: bold } // Comment.Preproc
-    .c1    { color: #998; font-style: italic } // Comment.Single
-    .cs    { color: #999; font-weight: bold; font-style: italic } // Comment.Special
-    .gd    { color: #000; background-color: #fdd } // Generic.Deleted
-    .gd .x { color: #000; background-color: #faa } // Generic.Deleted.Specific
-    .ge    { font-style: italic } // Generic.Emph
-    .gr    { color: #a00 } // Generic.Error
-    .gh    { color: #999 } // Generic.Heading
-    .gi    { color: #000; background-color: #dfd } // Generic.Inserted
-    .gi .x { color: #000; background-color: #afa } // Generic.Inserted.Specific
-    .go    { color: #888 } // Generic.Output
-    .gp    { color: #555 } // Generic.Prompt
-    .gs    { font-weight: bold } // Generic.Strong
-    .gu    { color: #aaa } // Generic.Subheading
-    .gt    { color: #a00 } // Generic.Traceback
-    .kc    { font-weight: bold } // Keyword.Constant
-    .kd    { font-weight: bold } // Keyword.Declaration
-    .kp    { font-weight: bold } // Keyword.Pseudo
-    .kr    { font-weight: bold } // Keyword.Reserved
-    .kt    { color: #458; font-weight: bold } // Keyword.Type
-    .m     { color: #099 } // Literal.Number
-    .s     { color: #d14 } // Literal.String
-    .na    { color: #008080 } // Name.Attribute
-    .nb    { color: #0086B3 } // Name.Builtin
-    .nc    { color: #458; font-weight: bold } // Name.Class
-    .no    { color: #008080 } // Name.Constant
-    .ni    { color: #800080 } // Name.Entity
-    .ne    { color: #900; font-weight: bold } // Name.Exception
-    .nf    { color: #900; font-weight: bold } // Name.Function
-    .nn    { color: #555 } // Name.Namespace
-    .nt    { color: #000080 } // Name.Tag
-    .nv    { color: #008080 } // Name.Variable
-    .ow    { font-weight: bold } // Operator.Word
-    .w     { color: #bbb } // Text.Whitespace
-    .mf    { color: #099 } // Literal.Number.Float
-    .mh    { color: #099 } // Literal.Number.Hex
-    .mi    { color: #099 } // Literal.Number.Integer
-    .mo    { color: #099 } // Literal.Number.Oct
-    .sb    { color: #d14 } // Literal.String.Backtick
-    .sc    { color: #d14 } // Literal.String.Char
-    .sd    { color: #d14 } // Literal.String.Doc
-    .s2    { color: #d14 } // Literal.String.Double
-    .se    { color: #d14 } // Literal.String.Escape
-    .sh    { color: #d14 } // Literal.String.Heredoc
-    .si    { color: #d14 } // Literal.String.Interpol
-    .sx    { color: #d14 } // Literal.String.Other
-    .sr    { color: #009926 } // Literal.String.Regex
-    .s1    { color: #d14 } // Literal.String.Single
-    .ss    { color: #990073 } // Literal.String.Symbol
-    .bp    { color: #999 } // Name.Builtin.Pseudo
-    .vc    { color: #008080 } // Name.Variable.Class
-    .vg    { color: #008080 } // Name.Variable.Global
-    .vi    { color: #008080 } // Name.Variable.Instance
-    .il    { color: #099 } // Literal.Number.Integer.Long
+	.c     { color: #998; font-style: italic } // Comment
+	.err   { color: #a61717; background-color: #e3d2d2 } // Error
+	.k     { font-weight: bold } // Keyword
+	.o     { font-weight: bold } // Operator
+	.cm    { color: #998; font-style: italic } // Comment.Multiline
+	.cp    { color: #999; font-weight: bold } // Comment.Preproc
+	.c1    { color: #998; font-style: italic } // Comment.Single
+	.cs    { color: #999; font-weight: bold; font-style: italic } // Comment.Special
+	.gd    { color: #000; background-color: #fdd } // Generic.Deleted
+	.gd .x { color: #000; background-color: #faa } // Generic.Deleted.Specific
+	.ge    { font-style: italic } // Generic.Emph
+	.gr    { color: #a00 } // Generic.Error
+	.gh    { color: #999 } // Generic.Heading
+	.gi    { color: #000; background-color: #dfd } // Generic.Inserted
+	.gi .x { color: #000; background-color: #afa } // Generic.Inserted.Specific
+	.go    { color: #888 } // Generic.Output
+	.gp    { color: #555 } // Generic.Prompt
+	.gs    { font-weight: bold } // Generic.Strong
+	.gu    { color: #aaa } // Generic.Subheading
+	.gt    { color: #a00 } // Generic.Traceback
+	.kc    { font-weight: bold } // Keyword.Constant
+	.kd    { font-weight: bold } // Keyword.Declaration
+	.kp    { font-weight: bold } // Keyword.Pseudo
+	.kr    { font-weight: bold } // Keyword.Reserved
+	.kt    { color: #458; font-weight: bold } // Keyword.Type
+	.m     { color: #099 } // Literal.Number
+	.s     { color: #d14 } // Literal.String
+	.na    { color: #008080 } // Name.Attribute
+	.nb    { color: #0086B3 } // Name.Builtin
+	.nc    { color: #458; font-weight: bold } // Name.Class
+	.no    { color: #008080 } // Name.Constant
+	.ni    { color: #800080 } // Name.Entity
+	.ne    { color: #900; font-weight: bold } // Name.Exception
+	.nf    { color: #900; font-weight: bold } // Name.Function
+	.nn    { color: #555 } // Name.Namespace
+	.nt    { color: #000080 } // Name.Tag
+	.nv    { color: #008080 } // Name.Variable
+	.ow    { font-weight: bold } // Operator.Word
+	.w     { color: #bbb } // Text.Whitespace
+	.mf    { color: #099 } // Literal.Number.Float
+	.mh    { color: #099 } // Literal.Number.Hex
+	.mi    { color: #099 } // Literal.Number.Integer
+	.mo    { color: #099 } // Literal.Number.Oct
+	.sb    { color: #d14 } // Literal.String.Backtick
+	.sc    { color: #d14 } // Literal.String.Char
+	.sd    { color: #d14 } // Literal.String.Doc
+	.s2    { color: #d14 } // Literal.String.Double
+	.se    { color: #d14 } // Literal.String.Escape
+	.sh    { color: #d14 } // Literal.String.Heredoc
+	.si    { color: #d14 } // Literal.String.Interpol
+	.sx    { color: #d14 } // Literal.String.Other
+	.sr    { color: #009926 } // Literal.String.Regex
+	.s1    { color: #d14 } // Literal.String.Single
+	.ss    { color: #990073 } // Literal.String.Symbol
+	.bp    { color: #999 } // Name.Builtin.Pseudo
+	.vc    { color: #008080 } // Name.Variable.Class
+	.vg    { color: #008080 } // Name.Variable.Global
+	.vi    { color: #008080 } // Name.Variable.Instance
+	.il    { color: #099 } // Literal.Number.Integer.Long
 }

--- a/css/main.scss
+++ b/css/main.scss
@@ -45,22 +45,22 @@ $medium:           992px;
 //     }
 // }
 @mixin media-query($device) {
-    @media only screen and (max-width: $device) {
-        @content;
-    }
+	@media only screen and (max-width: $device) {
+		@content;
+	}
 }
 
 // Import partials from `sass_dir` (defaults to `_sass`)
 @import
-    "base",
-    "layout",
-    "syntax-highlighting",
-		"header",
-		"sidebar",
-		"default",
-		"an",
-		"grid",
-		"pagination",
-		"mobile",
-		"share"
+	"base",
+	"layout",
+	"syntax-highlighting",
+	"header",
+	"sidebar",
+	"default",
+	"an",
+	"grid",
+	"pagination",
+	"mobile",
+	"share"
 ;

--- a/css/main.scss
+++ b/css/main.scss
@@ -50,13 +50,6 @@ $medium:         992px;
     }
 }
 
-// Box sizing mixin
-@mixin bsizing($box) {
-  -webkit-box-sizing: $box;
-  -moz-box-sizing: $box;
-  box-sizing: $box;
-}
-
 // Box shadow mixin
 @mixin bshadow($svars...) {
   -webkit-box-shadow: $svars;

--- a/css/main.scss
+++ b/css/main.scss
@@ -50,13 +50,6 @@ $medium:         992px;
     }
 }
 
-// Border radius mixin
-@mixin radius($radius...) {
-  -webkit-border-radius: $radius;
-  -moz-border-radius: $radius;
-  border-radius: $radius;
-}
-
 // Box sizing mixin
 @mixin bsizing($box) {
   -webkit-box-sizing: $box;

--- a/css/main.scss
+++ b/css/main.scss
@@ -26,16 +26,16 @@ $grey-color:       #828282;
 $grey-color-light: lighten($grey-color, 40%);
 $grey-color-dark:  darken($grey-color, 25%);
 
-$the-pink: #ea2485;
-$the-green:       #8bc63e;
-$the-blue:        #2b99c1;
-$the-yellow:      #ebdd14;
-$the-beige:		  #f1e5c6;
-$the-gray:		  #221e20;
-$the-light-beige: lighten($the-beige, 25%);
+$the-pink:         #ea2485;
+$the-green:        #8bc63e;
+$the-blue:         #2b99c1;
+$the-yellow:       #ebdd14;
+$the-beige:        #f1e5c6;
+$the-gray:         #221e20;
+$the-light-beige:  lighten($the-beige, 25%);
 
-$small:          768px;
-$medium:         992px;
+$small:            768px;
+$medium:           992px;
 
 // Using media queries with like this:
 // @include media-query($palm) {
@@ -52,9 +52,9 @@ $medium:         992px;
 
 // Import partials from `sass_dir` (defaults to `_sass`)
 @import
-        "base",
-        "layout",
-        "syntax-highlighting",
+    "base",
+    "layout",
+    "syntax-highlighting",
 		"header",
 		"sidebar",
 		"default",

--- a/css/main.scss
+++ b/css/main.scss
@@ -50,15 +50,6 @@ $medium:         992px;
     }
 }
 
-// Fade mixin
-@mixin fade-transition($fvars...) {
-  -webkit-transition: $fvars;
-  -moz-transition: $fvars;
-  -ms-transition: $fvars;
-  -o-transition: $fvars;
-  transition: $fvars;
-}
-
 // Border radius mixin
 @mixin radius($radius...) {
   -webkit-border-radius: $radius;

--- a/css/main.scss
+++ b/css/main.scss
@@ -50,13 +50,6 @@ $medium:         992px;
     }
 }
 
-// Box shadow mixin
-@mixin bshadow($svars...) {
-  -webkit-box-shadow: $svars;
-  -moz-box-shadow: $svars;
-  box-shadow: $svars;
-}
-
 // Import partials from `sass_dir` (defaults to `_sass`)
 @import
         "base",


### PR DESCRIPTION
This PR does two kinds of things:

1. Deletes outdated vendor prefixing mixins. At the time of these files original authoring, this kind of mixin was necessary for browser support of certain CSS properties. Those browsers now either see extremely little use (Opera) or support the same CSS properties unprefixed (Safari, Edge, Firefox, Chrome). These mixins are:
    - `@mixin fade-transition`, replaced by `transition`
    - `@mixin radius`, replaced by `border-radius`
    - `@mixin bsizing`, replaced by `box-sizing`
    - `@mixin bshadow`, replaced by `box-shadow`

    Altogether, this step removes about 66 lines of extraneous compiled CSS.

2. Straightens out the Sass files in terms of indentation, tabs vs. spaces, whether gaps in between code blocks are composed of spaces/tabs or are just newlines, etc. I tried to figure out what seemed like the most standardized bit.

If you'd prefer that these things be split out into separate PRs, just let me know and I'd be happy to do that -- in truth, I was planning on doing the second part separately to begin with, but my editor settings went ahead and autoremoved those inter-block new-line tabs while I was working on the mixins, and I didn't notice until today! So: I decided to do the rest of it in the same branch.

Also, please let me know if you have a specific preference for tabs vs. spaces (and if you have a preference towards tabs in between code blocks), and I'll configure my editor for this repo accordingly.